### PR TITLE
Extend isbot interface to "any"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+### New features
+-   Typescript definition (isbot) supports any. Where a non-string argument is cast to a string before execution
+
 ## 3.1.0
 ### New features
 -   Native support for ESM and CommonJS

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 /**
  * Detect if a user agent is a bot, crawler or spider
- * @param ua A user agent string
+ * @param ua A user agent string. Non strings will be cast to string before the check
  */
-declare function isbot(ua: string): boolean;
+declare function isbot(ua: any): boolean;
 
 declare namespace isbot {
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "🤖 detect bots/crawlers/spiders via the user agent.",
   "keywords": [
     "bot",


### PR DESCRIPTION
Resolve #149 

Typescript definition supports any. Where a non-string argument is cast to a string before execution