### PR TITLE
Add "spawn" interface

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ scripts/*
 page/*
 docs/*
 
+babel.config.json
 tsconfig.json
 
 fixtures/*

--- a/.rollup.js
+++ b/.rollup.js
@@ -1,5 +1,6 @@
 const { join } = require('path')
-const json = require('@rollup/plugin-json');
+const json = require('@rollup/plugin-json')
+const { babel } = require('@rollup/plugin-babel')
 
 module.exports = [
   {
@@ -22,7 +23,8 @@ module.exports = [
       preferConst: true
     },
     plugins: [
-      json()
+      json(),
+      babel({ babelHelpers: 'bundled' })
     ]
   })
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.0
+-   Add "spawn" interface
+
 ## 3.2.4
 -   Add some RSS readers detection
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ Return the respective match for bot user agent rule
 isbot.find('Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0 DejaClick/2.9.7.2') // 'DejaClick'
 ```
 
+### Spawn: Create new instances
+Create new instances of isbot. Instance is spawned using spawner's list as base
+```js
+const one = isbot.spawn()
+const two = isbot.spawn()
+
+two.exclude(['chrome-lighthouse'])
+one('Chrome-Lighthouse') // true
+two('Chrome-Lighthouse') // false
+```
+Create isbot using custom list (**instead** of the maintained list)
+```js
+const lean = isbot.spawn([ 'bot' ])
+lean('Googlebot') // true
+lean('Chrome-Lighthouse') // false
+```
+
 ## Definitions
 -   **Bot.** Autonomous program imitating or replacing some aspect of a human behaviour, performing repetitive tasks much faster than human users could.
 -   **Good bot.** Automated programs who visit websites in order to collect useful information. Web crawlers, site scrapers, stress testers, preview builders and other programs are welcomed on most websites because they serve purposes of mutual benefits.
@@ -96,13 +113,13 @@ Missing something? Please [open an issue](https://github.com/omrilotan/isbot/iss
 
 ## Major releases breaking changes ([full changelog](./CHANGELOG.md))
 
-### [Version 3](https://github.com/omrilotan/isbot/releases/tag/v3.0.0)
+### [**Version 3**](https://github.com/omrilotan/isbot/releases/tag/v3.0.0)
 Remove testing for node 6 and 8
 
-### [Version 2](https://github.com/omrilotan/isbot/releases/tag/v2.0.0)
+### [**Version 2**](https://github.com/omrilotan/isbot/releases/tag/v2.0.0)
 Change return value for isbot: `true` instead of matched string
 
-### [Version 1](https://github.com/omrilotan/isbot/releases/tag/v1.0.0)
+### [**Version 1**](https://github.com/omrilotan/isbot/releases/tag/v1.0.0)
 No functional change
 
 ## Real world data

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": "> 0.25%, not dead"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/fixtures/browsers.yml
+++ b/fixtures/browsers.yml
@@ -13,6 +13,7 @@ Amiga:
   - Amiga-AWeb/3.4.167SE
   - AmigaVoyager/3.4.4 (MorphOS/PPC native)
   - IBrowse/2.4demo (AmigaOS 3.9; 68K)
+  - IBrowse/2.5.4demo (Amiga; AmigaOS 3.1.4; Build 25.96 68K)
   - Mozilla/5.0 (Amiga; PowerPC AmigaOS 4.1; Odyssey Web Browser; rv:1.23) AppleWebKit/538.1 (KHTML, like Gecko) OWB/1.23 Safari/538.1
   - Mozilla/5.0 (AmigaOs; 4.0; en-US; rv:1.8.1.21pre)  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.666.4147.105 Safari/537.36
   - Mozilla/5.0 (compatible; IBrowse 2.5.3; AmigaOS 3.1.2)

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,21 +7,28 @@ declare function isbot(ua: any): boolean;
 declare namespace isbot {
   /**
    * Extend the built-in list of bot user agent
-   * @param filters An array of user agents
+   * @param {string[]} filters An array of regular expression patterns
    */
   function extend(filters: string[]): void;
 
   /**
    * Removes a set of user agent from the built-in list
-   * @param filters An array of user agents
+   * @param {string[]} filters An array of regular expression patterns
    */
   function exclude(filters: string[]): void;
 
   /**
    * Return the respective match for bot user agent rule
-   * @param ua A user agent string
+   * @param {string} ua A user agent string
    */
   function find(ua: string): string;
+
+  /**
+   * Create a new isbot function complete with all its interface
+   * @param {string[]} list of strings representing regular expression patterns
+   * @returns isbot function with full interface
+   */
+  function spawn(list?: string[]): isbot;
 }
 
 export = isbot;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,34 +1,34 @@
-/**
- * Detect if a user agent is a bot, crawler or spider
- * @param ua A user agent string. Non strings will be cast to string before the check
- */
-declare function isbot(ua: any): boolean;
+interface isbot {
+  /**
+   * Detect if a user agent is a bot, crawler or spider
+   * @param {string} ua A user agent string. Non strings will be cast to string before the check
+   */
+  (ua: any): boolean;
 
-declare namespace isbot {
   /**
    * Extend the built-in list of bot user agent
    * @param {string[]} filters An array of regular expression patterns
    */
-  function extend(filters: string[]): void;
+  extend(filters: string[]): void;
 
   /**
    * Removes a set of user agent from the built-in list
    * @param {string[]} filters An array of regular expression patterns
    */
-  function exclude(filters: string[]): void;
+  exclude(filters: string[]): void;
 
   /**
    * Return the respective match for bot user agent rule
    * @param {string} ua A user agent string
    */
-  function find(ua: string): string;
+  find(ua: string): string;
 
   /**
    * Create a new isbot function complete with all its interface
    * @param {string[]} list of strings representing regular expression patterns
    * @returns isbot function with full interface
    */
-  function spawn(list?: string[]): isbot;
+  spawn(list?: string[]): isbot;
 }
 
 export = isbot;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,26 +2,30 @@ interface isbot {
   /**
    * Detect if a user agent is a bot, crawler or spider
    * @param {string} ua A user agent string. Non strings will be cast to string before the check
+   * @returns {boolean}
    */
   (ua: any): boolean;
 
   /**
    * Extend the built-in list of bot user agent
    * @param {string[]} filters An array of regular expression patterns
+   * @returns {void}
    */
   extend(filters: string[]): void;
 
   /**
    * Removes a set of user agent from the built-in list
    * @param {string[]} filters An array of regular expression patterns
+   * @returns {void}
    */
   exclude(filters: string[]): void;
 
   /**
    * Return the respective match for bot user agent rule
    * @param {string} ua A user agent string
+   * @returns {string|null}
    */
-  find(ua: string): string;
+  find(ua: string): string|null;
 
   /**
    * Create a new isbot function complete with all its interface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "3.3.0-rc.1",
+  "version": "3.3.0-rc.2",
   "description": "🤖 detect bots/crawlers/spiders via the user agent.",
   "keywords": [
     "bot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "3.2.3",
+  "version": "3.3.0-rc.1",
   "description": "🤖 detect bots/crawlers/spiders via the user agent.",
   "keywords": [
     "bot",
@@ -58,16 +58,19 @@
     "symlink": "./scripts/symlink/index.js",
     "prebrowser": "npm run ensure && npm run symlink && rollup --config tests/browser/rollup.js",
     "browser": "karma start tests/browser/karma.js",
-    "lint": "standard",
+    "lint": "standard --parser @babel/eslint-parser",
     "remark": "remark .",
     "prets": "npm run ensure",
     "ts": "tsc",
     "prepublishOnly": "npm run authors && npm run build"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.14.7",
+    "@babel/preset-env": "^7.14.8",
     "@lets/wait": "^2.0.2",
+    "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.4",
     "eslint-plugin-log": "^1.2.6",
     "form-data": "^4.0.0",
     "karma": "^6.3.4",
@@ -76,15 +79,15 @@
     "karma-firefox-launcher": "^2.1.1",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "mocha": "^9.0.1",
+    "mocha": "^9.0.3",
     "pug": "^3.0.0",
     "remark-cli": "^9.0.0",
     "remark-preset-lint-recommended": "^5.0.0",
-    "rollup": "^2.52.7",
+    "rollup": "^2.55.0",
     "standard": "^16.0.3",
     "stdline": "^1.0.0",
     "typescript": "^4.3.5",
-    "user-agents": "^1.0.701",
+    "user-agents": "^1.0.727",
     "yaml": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "3.3.0-rc.2",
+  "version": "3.3.0",
   "description": "🤖 detect bots/crawlers/spiders via the user agent.",
   "keywords": [
     "bot",

--- a/scripts/lib/client/index.js
+++ b/scripts/lib/client/index.js
@@ -33,7 +33,7 @@ module.exports = function client ({ url, method = 'GET', data, headers = {} } = 
               headers
             )
           },
-          (response) => {
+          response => {
             if (Math.floor(response.statusCode / 100) !== 2) {
               const error = new Error(response.statusText)
               error.code = response.statusCode
@@ -59,7 +59,7 @@ module.exports = function client ({ url, method = 'GET', data, headers = {} } = 
           }
         ).on(
           'error',
-          (error) => reject(error)
+          reject
         )
 
         form && form.pipe(instance)

--- a/src/amend/index.js
+++ b/src/amend/index.js
@@ -7,27 +7,30 @@ export function amend (list) {
   try {
     // Risk: Uses lookbehind assertion, avoid breakage in parsing by using RegExp constructor
     new RegExp('(?<! cu)bot').test('dangerbot') // eslint-disable-line prefer-regex-literals
-    // Addresses: Cubot device
-    list.splice(list.lastIndexOf('bot'), 1)
-    list.push('(?<! cu)bot')
-    // Addresses: Android webview
-    list.splice(list.lastIndexOf('google'), 1)
-    list.push('(?<! (channel\\/|google\\/))google(?!(app|\\/google))')
-
-    // Addresses: Yandex browser
-    list.splice(list.lastIndexOf('search'), 1)
-    list.push('(?<! (ya|yandex))search')
-    // Addresses: libhttp browser
-    list.splice(list.lastIndexOf('http'), 1)
-    list.push('(?<!(lib))http')
-    // Addresses: java based browsers
-    list.splice(list.lastIndexOf('java'), 1)
-    list.push('java(?!;)')
-    // Addresses: java based browsers
-    list.splice(list.lastIndexOf('fetch'), 1)
-    list.push('(?<!(mozac))fetch')
   } catch (error) {
-    // ignore errors
+    // Skip regex fixes
+    return list
   }
+
+  // Addresses: Cubot device
+  list.splice(list.lastIndexOf('bot'), 1)
+  list.push('(?<! cu)bot')
+  // Addresses: Android webview
+  list.splice(list.lastIndexOf('google'), 1)
+  list.push('(?<! (channel\\/|google\\/))google(?!(app|\\/google))')
+
+  // Addresses: Yandex browser
+  list.splice(list.lastIndexOf('search'), 1)
+  list.push('(?<! (ya|yandex))search')
+  // Addresses: libhttp browser
+  list.splice(list.lastIndexOf('http'), 1)
+  list.push('(?<!(lib))http')
+  // Addresses: java based browsers
+  list.splice(list.lastIndexOf('java'), 1)
+  list.push('java(?!;)')
+  // Addresses: java based browsers
+  list.splice(list.lastIndexOf('fetch'), 1)
+  list.push('(?<!(mozac))fetch')
+
   return list
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import { Isbot } from './isbot/index.js'
 
 const createInterface = instance => Object.defineProperties(
-  ua => instance.test(ua),
+  function isbot(ua) {
+    return instance.test(ua)
+  },
   {
     find: { get: () => ua => instance.find(ua) },
     extend: { get: () => list => instance.extend(list) },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Isbot } from './isbot/index.js'
 
 const createInterface = instance => Object.defineProperties(
-  function isbot(ua) {
+  function isbot (ua) {
     return instance.test(ua)
   },
   {

--- a/src/index.js
+++ b/src/index.js
@@ -1,85 +1,15 @@
-import list from './list.json'
-import { amend } from './amend/index.js'
+import { Isbot } from './isbot/index.js'
 
-amend(list)
-let pattern
-
-/**
- * Refresh the local regex variable (clusure)
- */
-function update () {
-  pattern = new RegExp(list.join('|'), 'i')
-}
-
-/**
- * Check if string matches known crawler patterns
- * @param  {string} ua User Agent String
- * @return {boolean}
- */
-const isbot = ua => pattern.test(ua)
-
-/**
- * Get the match for strings' known crawler pattern
- * @param  {string} ua
- * @return {string}
- */
-function find (ua) {
-  const match = ua.match(pattern)
-  return match && match[0]
-}
-
-/**
- * Find the first index of an existing rule or -1 if not found
- * @param  {string} rule
- * @returns {number}
- */
-const indexOf = (rule) => list.indexOf(rule.toLowerCase())
-
-/**
- * Check if item is included in list
- * @param  {string} rule
- * @return {boolean}
- */
-const included = (rule) => indexOf(rule) === -1
-
-/**
- * Extent patterns for known crawlers
- * @param  {string[]} filters
- * @return {void}
- */
-function extend (filters) {
-  [].push.apply(
-    list,
-    filters.filter(included).map(filter => filter.toLowerCase())
-  )
-  update()
-}
-
-/**
- * Exclude patterns from bot pattern rule
- * @param  {string[]} filters
- * @return {void}
- */
-function exclude (filters) {
-  let { length } = filters
-  while (length--) {
-    const index = indexOf(filters[length])
-    if (index > -1) {
-      list.splice(index, 1)
-    }
-  }
-  update()
-}
-
-Object.defineProperties(
-  isbot,
+const createInterface = instance => Object.defineProperties(
+  ua => instance.test(ua),
   {
-    find: { get: () => find },
-    extend: { get: () => extend },
-    exclude: { get: () => exclude }
+    find: { get: () => ua => instance.find(ua) },
+    extend: { get: () => list => instance.extend(list) },
+    exclude: { get: () => list => instance.exclude(list) },
+    spawn: { get: () => list => createInterface(instance.spawn(list)) }
   }
 )
 
-update()
+const isbot = createInterface(new Isbot())
 
 export default isbot

--- a/src/isbot/index.js
+++ b/src/isbot/index.js
@@ -1,0 +1,91 @@
+import list from '../list.json'
+import { amend } from '../amend/index.js'
+
+amend(list)
+
+/**
+ *
+ */
+export class Isbot {
+  #list;
+  #pattern;
+  constructor (patterns) {
+    if (patterns) {
+      this.#list = patterns
+    } else {
+      this.#list = list.slice()
+    }
+    this.#update()
+  }
+
+  #update () {
+    this.#pattern = new RegExp(
+      this.#list.join('|'),
+      'i'
+    )
+  }
+
+  /**
+   * Find the first index of an existing rule or -1 if not found
+   * @param  {string} rule
+   * @returns {number}
+   */
+  #index (rule) {
+    return this.#list.indexOf(rule.toLowerCase())
+  }
+
+  get list () {
+    return this.#list
+  }
+
+  test (ua) {
+    return this.#pattern.test(ua)
+  }
+
+  /**
+   * Get the match for strings' known crawler pattern
+   * @param  {string} ua
+   * @return {string}
+   */
+  find (ua) {
+    const match = ua.match(this.#pattern)
+    return match && match[0]
+  }
+
+  /**
+   * Extent patterns for known crawlers
+   * @param  {string[]} filters
+   * @return {void}
+   */
+  extend (filters) {
+    [].push.apply(
+      this.#list,
+      filters.filter(
+        (rule) => this.#index(rule) === -1
+      ).map(
+        filter => filter.toLowerCase()
+      )
+    )
+    this.#update()
+  }
+
+  /**
+   * Exclude patterns from bot pattern rule
+   * @param  {string[]} filters
+   * @return {void}
+   */
+  exclude (filters) {
+    let { length } = filters
+    while (length--) {
+      const index = this.#index(filters[length])
+      if (index > -1) {
+        this.#list.splice(index, 1)
+      }
+    }
+    this.#update()
+  }
+
+  spawn (list) {
+    return new Isbot(list || this.#list)
+  }
+}

--- a/src/isbot/index.js
+++ b/src/isbot/index.js
@@ -69,7 +69,7 @@ export class Isbot {
     [].push.apply(
       this.#list,
       filters.filter(
-        (rule) => this.#index(rule) === -1
+        rule => this.#index(rule) === -1
       ).map(
         filter => filter.toLowerCase()
       )

--- a/src/isbot/index.js
+++ b/src/isbot/index.js
@@ -4,20 +4,27 @@ import { amend } from '../amend/index.js'
 amend(list)
 
 /**
- *
+ * Test user agents for matching patterns
  */
 export class Isbot {
+  /**
+   * @type {string[]}
+   */
   #list;
+
+  /**
+   * @type {RegExp}
+   */
   #pattern;
+
   constructor (patterns) {
-    if (patterns) {
-      this.#list = patterns
-    } else {
-      this.#list = list.slice()
-    }
+    this.#list = patterns || list.slice()
     this.#update()
   }
 
+  /**
+   * Recreate the pattern from rules list
+   */
   #update () {
     this.#pattern = new RegExp(
       this.#list.join('|'),
@@ -34,20 +41,21 @@ export class Isbot {
     return this.#list.indexOf(rule.toLowerCase())
   }
 
-  get list () {
-    return this.#list
-  }
-
+  /**
+   * Match given string against out pattern
+   * @param  {string} ua User Agent string
+   * @returns {boolean}
+   */
   test (ua) {
     return this.#pattern.test(ua)
   }
 
   /**
    * Get the match for strings' known crawler pattern
-   * @param  {string} ua
-   * @return {string}
+   * @param  {string} ua User Agent string
+   * @returns {string}
    */
-  find (ua) {
+  find (ua = '') {
     const match = ua.match(this.#pattern)
     return match && match[0]
   }
@@ -55,9 +63,9 @@ export class Isbot {
   /**
    * Extent patterns for known crawlers
    * @param  {string[]} filters
-   * @return {void}
+   * @returns {void}
    */
-  extend (filters) {
+  extend (filters = []) {
     [].push.apply(
       this.#list,
       filters.filter(
@@ -72,9 +80,9 @@ export class Isbot {
   /**
    * Exclude patterns from bot pattern rule
    * @param  {string[]} filters
-   * @return {void}
+   * @returns {void}
    */
-  exclude (filters) {
+  exclude (filters = []) {
     let { length } = filters
     while (length--) {
       const index = this.#index(filters[length])
@@ -85,6 +93,11 @@ export class Isbot {
     this.#update()
   }
 
+  /**
+   * Create a new Isbot instance using given list or self's list
+   * @param  {string[]} [list]
+   * @returns {Isbot}
+   */
   spawn (list) {
     return new Isbot(list || this.#list)
   }

--- a/tests/specs/spec.js
+++ b/tests/specs/spec.js
@@ -2,7 +2,6 @@
 
 import { strict as assert } from 'assert'
 import isbot from '../../src/index.js'
-import { amend } from '../../src/amend/index.js'
 import fixtures from '../../fixtures/index.json'
 
 const { browsers = [], crawlers = [] } = fixtures

--- a/tests/specs/spec.js
+++ b/tests/specs/spec.js
@@ -2,6 +2,7 @@
 
 import { strict as assert } from 'assert'
 import isbot from '../../src/index.js'
+import { amend } from '../../src/amend/index.js'
 import fixtures from '../../fixtures/index.json'
 
 const { browsers = [], crawlers = [] } = fixtures

--- a/tests/specs/spec.js
+++ b/tests/specs/spec.js
@@ -10,6 +10,10 @@ const { equal, fail } = assert
 describe(
   'specs',
   () => {
+    it('should not break with empty input', () => {
+      equal(isbot(), false)
+    })
+
     it(`should return false for all ${browsers.length} browsers`, () => {
       const recognised = browsers.filter(isbot)
       recognised.length && fail([
@@ -68,6 +72,10 @@ describe(
     })
 
     describe('isbot.find', () => {
+      it('should not break with empty input', () => {
+        equal(isbot.find(), null)
+      })
+
       it('should return null for non bot browser', () => {
         equal(isbot.find('Mozilla'), null)
       })

--- a/tests/specs/spec.js
+++ b/tests/specs/spec.js
@@ -44,6 +44,7 @@ describe(
         isbot.extend([rule])
         isbot.extend([rule])
         isbot.exclude([rule])
+        console.log(isbot.list)
         assert(!isbot(useragent))
       })
     })
@@ -73,6 +74,33 @@ describe(
 
       it('should return the rule used to identify as bot', () => {
         equal(isbot.find('Mozilla/5.0 (compatible; SemrushBot-SA/0.97; +http://www.semrush.com/bot.html)'), 'Bot')
+      })
+    })
+
+    describe('isbot.spawn', () => {
+      it('should spawn isbot with its own list', () => {
+        const newUA = 'nothing'
+        const botUA = 'Mozilla/5.0 (compatible; SemrushBot-SA/0.97; +http://www.semrush.com/bot.html)'
+        const isbot2 = isbot.spawn([newUA])
+        assert(!isbot(newUA))
+        assert(isbot2(newUA))
+        assert(isbot(botUA))
+        assert(!isbot2(botUA))
+      })
+      it('should not affect each others lists', () => {
+        const newUA = 'nothing'
+        const isbot1 = isbot.spawn()
+        const isbot2 = isbot.spawn()
+        isbot1.extend([newUA])
+        assert(isbot1(newUA))
+        assert(!isbot2(newUA))
+      })
+      it('should spawn from instance\'s list', () => {
+        const newUA = 'nothing'
+        const isbot1 = isbot.spawn()
+        isbot1.extend([newUA])
+        const isbot2 = isbot1.spawn()
+        assert(isbot2(newUA))
       })
     })
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["index.js", "index.d.ts"],
+  "include": ["index.d.ts", "src/index.js", "src/**/index.js"],
   "exclude": []
 }


### PR DESCRIPTION
Created an internal class.
Since the default exports is a function, _which is backwards compatible, and also very simple for out-of-the-box use_, I've added a "spawn" wrapper function, similar to "extend", "exclude" and "find".

Releasing this as a release candidate so I can test it in different environments before we continue to a public release.

Testing release candidate:
```
npm i isbot@spawn
```

Resolve #153 