### PR TITLE
Update build tools (rollup, babel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+## [3.5.2](https://github.com/omrilotan/isbot/compare/v3.5.1...v3.5.2)
+-   Build supports more interpolation (transform class etc.)
+
 ## [3.5.1](https://github.com/omrilotan/isbot/compare/v3.5.0...v3.5.1)
 -   Add SERP (Search Engine Results Pages) Reputation Management tools
+
 ## [3.5.0](https://github.com/omrilotan/isbot/compare/v3.4.8...v3.5.0)
 -   Specify browser and node entries for require and import (resolves issue with jest 28)
 

--- a/fixtures/browsers.yml
+++ b/fixtures/browsers.yml
@@ -661,6 +661,7 @@ ZZZ Glitches and Misidentified Browsers - These browsers are legit user agent ev
   - ; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.45 Mobile DuckDuckGo/5 Safari/537.36
   - asafaweb.com
   - custom user agent0
+  - daumoa,damoa,daum,daumos,duamoa,duam,duamos
   - Hello, world
   - iexplore.exe
   - LWPrCa2l') OR 941=(SELECT 941 FROM PG_SLEEP(15))--

--- a/fixtures/crawlers.yml
+++ b/fixtures/crawlers.yml
@@ -816,10 +816,12 @@ ZoomBot (seozoom.it):
   - zoombot (linkbot 1.0 http://suite.seozoom.it/bot.html)
 ZumBot:
   - ZumBot/1.0 (ZUM Search; http://help.zum.com/inquiry)
-ZZZ Glitches and Errornous User Agent Strings:
+ZZZ Miscellaneous Glitches and Errornous User Agent Strings:
   - "123"
   - Chrome
   - default_user_agent
   - ipad
   - iphone 6 plus;afengineurl=https://intoli.com:443;traceId=63028f8e-c5fc-4846-993f-59a96268a85d
+  - pisya
+  - search.marginalia.nu
   - U2FsdGVkX1+uKxeH2946/bMTDvtm/Fr0nWjvFR/oPtc64LSh1Gg0qkbJUIhLpSw5h/mjF86TFOXrl4U2SG1KBi4BC0EfphyIzeOxVXkpBWHDMfJnkrFGrubrRGjmJNIN49DKkOcjVgq2/iVDBMSAQe30k9wNIDtflfnlrOrmDPkXiYNjLbohSHLaNWS/GK5hu62gkOH25c9i1B+jMq5kc590HoQqJ0o4es9QrEnwluMsYPbQy14LxgPjeCQveiPHPXtkSM7TmfTY53HEJdbFHylstSOJNTQclbL67BKx33M=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "🤖 detect bots/crawlers/spiders via the user agent.",
   "keywords": [
     "bot",
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-import-assertions": "^7.18.6",
-    "@babel/preset-env": "^7.18.6",
+    "@babel/preset-env": "^7.18.10",
     "@lets/wait": "^2.0.2",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.2.1",
@@ -94,12 +94,12 @@
     "pug": "^3.0.0",
     "remark-cli": "^11.0.0",
     "remark-preset-lint-recommended": "^6.0.0",
-    "rollup": "^2.76.0",
+    "rollup": "^2.78.1",
     "rollup-plugin-import-assert": "^2.1.0",
     "standard": "^17.0.0",
     "stdline": "^1.0.0",
     "typescript": "^4.7.4",
-    "user-agents": "^1.0.1111",
+    "user-agents": "^1.0.1117",
     "yaml": "^2.1.1"
   }
 }


### PR DESCRIPTION
- build supports more interpolation (interpolate private class fields etc.)
- Maintenance