### PR TITLE
Stop support EOL node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,9 @@ workflows:
           matrix:
             parameters:
               image:
-                - cimg/node:12.22
-                - cimg/node:14.18
-                - cimg/node:16.15
-                - cimg/node:18.4
-                - cimg/node:19.6
+                - cimg/node:16.20
+                - cimg/node:18.18
+                - cimg/node:20.7
                 - cimg/node:lts
                 - cimg/node:current
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.0](https://github.com/omrilotan/isbot/compare/v3.7.00...v4.0.0)
+-   Stop active support for EOL node versions 14, 12
+-   No code changes
+
 ## [3.7.00](https://github.com/omrilotan/isbot/compare/v3.6.13...v3.7.00)
 -   Expose iife and support JSDeliver CDN
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Missing something? Please [open an issue](https://github.com/omrilotan/isbot/iss
 
 ## Major releases breaking changes ([full changelog](./CHANGELOG.md))
 
+### [**Version 4**](https://github.com/omrilotan/isbot/releases/tag/v4.0.0)
+Remove testing for node 14 and 12
+
 ### [**Version 3**](https://github.com/omrilotan/isbot/releases/tag/v3.0.0)
 Remove testing for node 6 and 8
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,7 +1,10 @@
 {
   "presets": [
     [
-      "@babel/preset-env"
+      "@babel/preset-env",
+      {
+        "targets": "> 0.25%, not dead"
+      }
     ]
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/omrilotan/isbot"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
Node 14 reached the end of life in April 2023.