### PR TITLE
Update bot pattern to exclude FuboTV OS

### DIFF
--- a/src/patterns.json
+++ b/src/patterns.json
@@ -5,7 +5,7 @@
   "(?:^| )site",
   "(?:^|[^g])news",
   "(?<! (?:channel/|google/))google(?!(app|/google| pixel))",
-  "(?<! cu)bot",
+  "(?<! cu)(?<!fu)bot",
   "(?<! ya(?:yandex)?)search",
   "(?<!(?:lib))http",
   "(?<![hg]m)score",


### PR DESCRIPTION
I was recently evaluating options to exclude bot traffic from some services I manage and came across an exception from sample user agents I was testing against `isbot`.

Example user agent:
```fuboTV/4.75.0 (Linux;Android 9; AFTDCT31 Build/PS7664.3772N) FuboPlayer/v1.34.0```

This is a TV OS web browser that happens to have `boT` in it's same, triggering the `(?<! cu)bot` to match. I added an exception in this rule as a separate negative lookbehind, but can re-write using something like a logical "or" if preferred!