### PR TITLE
Accept null in place of userAgent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.1.2](https://github.com/omrilotan/isbot/compare/v4.1.1...v4.1.2)
+
+- Accept `null` in place of user agent string to allow header value to be used "as is" (`request.headers.get("user-agent")`)
+
 ## [4.1.1](https://github.com/omrilotan/isbot/compare/v4.1.0...v4.1.1)
 
 - Recognise browsers with GMS Core ([Google's Play Services](https://github.com/microg/GmsCore/wiki)) as natural non-bot browsers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "🤖 Recognise bots/crawlers/spiders using the user agent string.",
   "keywords": [
     "bot",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,14 @@ export const list: string[] = patternsList;
 /**
  * Check if the given user agent includes a bot pattern.
  */
-export const isbot = (userAgent: string): boolean =>
+export const isbot = (userAgent: string | null): boolean =>
 	Boolean(userAgent) && pattern.test(userAgent);
 
 /**
  * Create a custom isbot function with a custom pattern.
  */
 export const createIsbot =
-	(customPattern: RegExp): ((userAgent: string) => boolean) =>
+	(customPattern: RegExp): ((userAgent: string | null) => boolean) =>
 	(userAgent: string): boolean =>
 		Boolean(userAgent) && customPattern.test(userAgent);
 
@@ -41,25 +41,29 @@ export const createIsbotFromList = (
 /**
  * Find the first part of the user agent that matches a bot pattern.
  */
-export const isbotMatch = (userAgent: string): string | null =>
-	userAgent.match(pattern)?.[0];
+export const isbotMatch = (userAgent: string | null): string | null =>
+	userAgent?.match(pattern)?.[0] ?? null;
 
 /**
  * Find all parts of the user agent that match a bot pattern.
  */
-export const isbotMatches = (userAgent: string): string[] =>
+export const isbotMatches = (userAgent: string | null): string[] =>
 	list
-		.map((part) => userAgent.match(new RegExp(part, "i"))?.[0])
+		.map((part) => userAgent?.match(new RegExp(part, "i"))?.[0])
 		.filter(Boolean);
 
 /**
  * Find the first bot patterns that match the given user agent.
  */
-export const isbotPattern = (userAgent: string): string | null =>
-	list.find((pattern) => new RegExp(pattern, "i").test(userAgent)) ?? null;
+export const isbotPattern = (userAgent: string | null): string | null =>
+	userAgent
+		? list.find((pattern) => new RegExp(pattern, "i").test(userAgent)) ?? null
+		: null;
 
 /**
  * Find all bot patterns that match the given user agent.
  */
-export const isbotPatterns = (userAgent: string): string[] =>
-	list.filter((pattern) => new RegExp(pattern, "i").test(userAgent));
+export const isbotPatterns = (userAgent: string | null): string[] =>
+	userAgent
+		? list.filter((pattern) => new RegExp(pattern, "i").test(userAgent))
+		: [];

--- a/tests/spec/test.ts
+++ b/tests/spec/test.ts
@@ -67,6 +67,13 @@ describe("isbot", () => {
 			expect(isbot(ua)).toBe(true);
 			expect(isbot2(ua)).toBe(false);
 		});
+		test("all functions can accept null", () => {
+			expect(isbot(null)).toBe(false);
+			expect(isbotMatch(null)).toBe(null);
+			expect(isbotMatches(null)).toEqual([]);
+			expect(isbotPattern(null)).toBe(null);
+			expect(isbotPatterns(null)).toEqual([]);
+		});
 	});
 
 	describe("fixtures", () => {


### PR DESCRIPTION
I can see it is a common use case to use the headers getter, which makes sense.

With this change, users will be able to remove the check by the user and maintain type compliance. This allows cleaner code for the user.

```diff
- isbot(request.headers.get("user-agent") || "")
+ isbot(request.headers.get("user-agent"))
```
