### PR TITLE
Build now compatibile with older Javascript version: es2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.1.0](https://github.com/omrilotan/isbot/compare/v5.0.0...v5.1.0)
+
+- Build now compatibile with older Javascript version: es2016
+
 ## [5.0.0](https://github.com/omrilotan/isbot/compare/v4.4.0...v5.0.0)
 
 - Remove named export "pattern" from the interface, instead use "getPattern" method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isbot",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "🤖/👨‍🦰 Recognise bots/crawlers/spiders using the user agent string.",
   "keywords": [
     "bot",

--- a/scripts/build/pattern.js
+++ b/scripts/build/pattern.js
@@ -11,8 +11,5 @@ const pattern = new RegExp(
 
 const expression = new RegExp(patterns.join("|"), "i").toString();
 
-const code = [
-	`export const fullPattern: string = "${pattern}";`,
-	`export const regularExpression: RegExp = ${expression};`,
-].join("\n");
+const code = `export const fullPattern: string = "${pattern}";\n`;
 await writeFile("src/pattern.ts", code);

--- a/scripts/build/procedure.sh
+++ b/scripts/build/procedure.sh
@@ -7,15 +7,15 @@ scripts/build/pattern.js
 failures=$((failures + $?))
 
 echo "→ Build commonjs"
-esbuild src/index.ts --outfile=index.js --bundle --platform=neutral --format=cjs --log-level=warning
+esbuild src/index.ts --outfile=index.js --bundle --platform=neutral --format=cjs --log-level=warning --target=es2016
 failures=$((failures + $?))
 
 echo "→ Build esm"
-esbuild src/index.ts --outfile=index.mjs --bundle --platform=neutral --format=esm --log-level=warning
+esbuild src/index.ts --outfile=index.mjs --bundle --platform=neutral --format=esm --log-level=warning --target=es2016
 failures=$((failures + $?))
 
 echo "→ Build browser file (iife)"
-esbuild src/browser.ts --outfile=index.iife.js --bundle --platform=neutral --format=iife --global-name=isbot --log-level=warning
+esbuild src/browser.ts --outfile=index.iife.js --bundle --platform=neutral --format=iife --global-name=isbot --log-level=warning --target=es2016
 failures=$((failures + $?))
 
 echo "→ Build TypeScript declaration file"

--- a/tests/spec/test.ts
+++ b/tests/spec/test.ts
@@ -10,7 +10,7 @@ import {
 	createIsbot,
 	createIsbotFromList,
 } from "../../src";
-import { fullPattern, regularExpression } from "../../src/pattern";
+import { fullPattern } from "../../src/pattern";
 import { crawlers, browsers } from "../../fixtures";
 let isbotInstance: any;
 


### PR DESCRIPTION
The build target is now set to es2016. This effectively removes `?.` and `??` operators from the built code, as well as `const`, `let` and so on.

Resolve #242