### PR TITLE
Explict Support for Kagi

### DIFF
--- a/fixtures/crawlers.yml
+++ b/fixtures/crawlers.yml
@@ -395,6 +395,8 @@ Jorgee Vulnerability Scanner:
   - Mozilla/5.0 Jorgee
 jsjcw_scanner:
   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36 jsjcw_scanner
+Kagi:
+  - Mozilla/5.0 (compatible; Kagibot/1.0; +https://kagi.com/bot)
 Kaspersky:
   - Kaspersky Lab CFR link resolver cfradmins@kaspersky.com
 keycdn:


### PR DESCRIPTION
This PR adds the User-Agent Kagi uses to populate it's own search index, documented on https://kagi.com/bot.

This isn't strictly needed, as the `bot` sub-string is correctly identified generically, but I was in the area, doubled-checking 🤷.