### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,6 @@
 name: CodeQL
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/omrilotan/isbot/security/code-scanning/3](https://github.com/omrilotan/isbot/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to operate. Based on the workflow's functionality, it primarily reads repository contents and performs analysis, so `contents: read` is sufficient. If additional permissions are required for specific jobs, they can be added later.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`analyze`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
